### PR TITLE
properly handle branch with slashes

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -13,7 +13,7 @@ def run():
     github_token = local.env.get('INPUT_GITHUB-TOKEN')
     commit_message = local.env.get('INPUT_COMMIT-MESSAGE')
     force_add = local.env.get('INPUT_FORCE-ADD')
-    branch = local.env.get('INPUT_PUSH-BRANCH') or local.env.get('GITHUB_REF').split('/')[2]
+    branch = local.env.get('INPUT_PUSH-BRANCH') or "/".join(local.env.get('GITHUB_REF').split('/')[2:])
     rebase = local.env.get('INPUT_REBASE', 'false')
     files = local.env.get('INPUT_FILES', '')
     email = local.env.get('INPUT_EMAIL', f'{github_actor}@users.noreply.github.com')


### PR DESCRIPTION
Fix for #17.

```
➜ python
Python 2.7.16 (default, Apr 17 2020, 18:29:03)
>>> x = "origin/paskal/test"
>>> x.split("/")[2]
'test'
>>> x.split("/")[1]
'paskal'
>>> x.split("/")[1:]
['paskal', 'test']
>>> "/".join(x.split("/")[1:])
'paskal/test'
>>> "/".join(x.split("/")[2:])
'test'
```